### PR TITLE
Enrich event jsonld with missing fields

### DIFF
--- a/src/components/EarthquakeDetailModalComponent.jsx
+++ b/src/components/EarthquakeDetailModalComponent.jsx
@@ -116,14 +116,26 @@ const EarthquakeDetailModalComponent = () => {
         const descriptionTime = time ? new Date(time).toLocaleTimeString('en-US', {hour: '2-digit', minute: '2-digit', timeZone: 'UTC'}) : 'Time Unknown';
         const pageDescription = `Detailed report of the M ${mag} earthquake that struck near ${place} on ${titleDate} at ${descriptionTime} (UTC). Magnitude: ${mag}, Depth: ${depth} km. Location: ${latitude?.toFixed(2)}, ${longitude?.toFixed(2)}. Stay updated with Earthquakes Live.`;
 
-        const pageKeywords = `earthquake, seismic event, M ${mag}, ${place ? place.split(', ').join(', ') : ''}, earthquake details, usgs event, ${usgsEventId}`;
+        // Enhanced keywords with date-related terms
+        let dateKeywords = '';
+        if (time) {
+            const dateObj = new Date(time);
+            const month = dateObj.toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' }).toLowerCase();
+            const year = dateObj.getFullYear();
+            const day = dateObj.getDate();
+            const formattedDate = dateObj.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).toLowerCase();
+            dateKeywords = `, ${month} ${year}, ${formattedDate}, earthquake ${month} ${year}`;
+        }
+        
+        const pageKeywords = `earthquake, seismic event, M ${mag}, ${place ? place.split(', ').join(', ') : ''}, earthquake details, usgs event, ${usgsEventId}${dateKeywords}`;
         // canonicalPageUrl uses detailUrlParam (which is params['*']) directly as per requirements.
         const canonicalPageUrl = `https://earthquakeslive.com/quake/${detailUrlParam}`;
 
         const eventLocation = {
             '@type': 'Place',
             name: place,
-            address: place, // Using place directly for address
+            // For earthquakes, we use place as address since it's typically a location description
+            ...(place && { address: place }),
         };
 
         if (typeof latitude === 'number' && typeof longitude === 'number') {
@@ -143,7 +155,7 @@ const EarthquakeDetailModalComponent = () => {
             startDate: time ? new Date(time).toISOString() : undefined,
             endDate: time ? new Date(time).toISOString() : undefined, // Added endDate
             eventAttendanceMode: 'https://schema.org/OnlineEvent', // Added eventAttendanceMode
-            eventStatus: 'https://schema.org/EventScheduled', // Added eventStatus
+            eventStatus: 'https://schema.org/EventCompleted', // Past earthquake event
             location: eventLocation,
             image: shakemapIntensityImageUrl || 'https://earthquakeslive.com/placeholder-image.jpg', // Added default image
             keywords: pageKeywords.toLowerCase(),

--- a/src/worker.js
+++ b/src/worker.js
@@ -232,8 +232,46 @@ async function handlePrerenderEarthquake(request, env, ctx, quakeIdPathSegment) 
     let significanceSentence = `This earthquake occurred at a depth of ${depth} km.`;
     if (depth < 70) significanceSentence = `This shallow earthquake (depth: ${depth} km) may have been felt by many people in the area.`;
     else if (depth > 300) significanceSentence = `This earthquake occurred very deep (depth: ${depth} km).`;
-    const keywords = `earthquake, ${place ? place.split(', ').join(', ') : ''}, M${mag}, seismic event, earthquake report`;
-    const jsonLd = {"@context": "https://schema.org", "@type": "Event", name: `M ${mag} - ${place}`, description, startDate: isoTime, location: {"@type": "Place", geo: {"@type": "GeoCoordinates", latitude: lat, longitude: lon, elevation: -depth * 1000 }, name: place }, identifier: quakeData.id, url: canonicalUrl, keywords: keywords.toLowerCase()};
+    // Enhanced keywords with date-related terms
+    const month = dateObj.toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' }).toLowerCase();
+    const year = dateObj.getFullYear();
+    const formattedDate = dateObj.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }).toLowerCase();
+    const dateKeywords = `, ${month} ${year}, ${formattedDate}, earthquake ${month} ${year}`;
+    const keywords = `earthquake, ${place ? place.split(', ').join(', ') : ''}, M${mag}, seismic event, earthquake report${dateKeywords}`;
+    
+    const jsonLd = {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        name: `M ${mag} - ${place}`,
+        description,
+        startDate: isoTime,
+        endDate: isoTime,
+        eventStatus: "https://schema.org/EventCompleted",
+        eventAttendanceMode: "https://schema.org/OnlineEvent",
+        location: {
+            "@type": "Place",
+            geo: {
+                "@type": "GeoCoordinates",
+                latitude: lat,
+                longitude: lon,
+                elevation: -depth * 1000
+            },
+            name: place,
+            ...(place && { address: place })
+        },
+        identifier: quakeData.id,
+        url: canonicalUrl,
+        keywords: keywords.toLowerCase(),
+        image: `https://earthquake.usgs.gov/earthquakes/eventpage/${quakeData.id}/map`,
+        organizer: {
+            "@type": "Organization",
+            name: "USGS"
+        },
+        performer: {
+            "@type": "Organization", 
+            name: "USGS"
+        }
+    };
     if (usgsEventUrl) jsonLd.sameAs = usgsEventUrl;
     const html = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${escapeXml(pageTitle)}</title><meta name="description" content="${escapeXml(description)}"><meta name="keywords" content="${escapeXml(keywords.toLowerCase())}"><link rel="canonical" href="${escapeXml(canonicalUrl)}"><meta name="twitter:card" content="summary_large_image"><meta name="twitter:site" content="@builtbyvibes"><meta property="og:title" content="${escapeXml(pageTitle)}"><meta property="og:description" content="${escapeXml(description)}"><meta property="og:url" content="${escapeXml(canonicalUrl)}"><meta property="og:type" content="website"><meta property="og:image" content="https://earthquakeslive.com/social-default-earthquake.png"><script type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</script></head><body><h1>${escapeXml(pageTitle)}</h1><p><strong>Time:</strong> ${escapeXml(readableTime)}</p><p><strong>Location:</strong> ${escapeXml(place)}</p><p><strong>Coordinates:</strong> ${lat.toFixed(4)}°N, ${lon.toFixed(4)}°E</p><p><strong>Magnitude:</strong> M ${mag}</p><p><strong>Depth:</strong> ${depth} km</p><p>${escapeXml(significanceSentence)}</p>${usgsEventUrl ? `<p><a href="${escapeXml(usgsEventUrl)}" target="_blank" rel="noopener noreferrer">View on USGS Event Page</a></p>` : ''}<div id="root"></div><script type="module" src="/src/main.jsx"></script></body></html>`;
     return new Response(html, { headers: { "Content-Type": "text/html", "Cache-Control": "public, s-maxage=3600" }});


### PR DESCRIPTION
Enhance Event JSON-LD structured data for earthquake events to improve search visibility and fill missing fields.

This PR adds date-related terms to the `keywords` field (e.g., 'june 2025', 'earthquake june 2025') to better match user search queries. It also populates several missing optional JSON-LD fields such as `eventStatus`, `eventAttendanceMode`, `organizer`, `performer`, `image`, `endDate`, and a structured `address`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ed0b712-a641-4467-8b61-cc5f254eaefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ed0b712-a641-4467-8b61-cc5f254eaefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

